### PR TITLE
Update to docker 18.09.6

### DIFF
--- a/.SRCINFO
+++ b/.SRCINFO
@@ -1,16 +1,16 @@
 pkgbase = nvidia-container-runtime-bin
 	pkgdesc = NVIDIA container runtime
-	pkgver = 2.0.0
+	pkgver = 2.0.0+3.docker18.09.6
 	pkgrel = 1
 	url = https://github.com/NVIDIA/nvidia-container-runtime
 	arch = x86_64
 	license = BSD
 	depends = libseccomp
 	depends = nvidia-container-runtime-hook
-	provides = nvidia-container-runtime=2.0.0+1.docker18.09.3
+	provides = nvidia-container-runtime=2.0.0+3.docker18.09.6
 	conflicts = nvidia-container-runtime
-	source = https://nvidia.github.io/nvidia-container-runtime/centos7/x86_64/nvidia-container-runtime-2.0.0-1.docker18.09.3.x86_64.rpm
-	sha256sums = baa919c98282f9a722ef51f987d5d672941f8e68337e582cebfcb0606812eb68
+	source = https://nvidia.github.io/nvidia-container-runtime/centos7/x86_64/nvidia-container-runtime-2.0.0-3.docker18.09.6.x86_64.rpm
+	sha256sums = 1d23d648709a12f3245f138129e24837fb978c5ef75f51bce17c3c5a9d40d1ab
 
 pkgname = nvidia-container-runtime-bin
 

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -4,7 +4,7 @@
 pkgname=nvidia-container-runtime-bin
 _pkgname=nvidia-container-runtime
 
-pkgver=2.0.0
+pkgver=2.0.0+3.docker18.09.6
 
 pkgrel=1
 pkgdesc='NVIDIA container runtime'
@@ -13,11 +13,11 @@ url='https://github.com/NVIDIA/nvidia-container-runtime'
 license=('BSD')
 
 depends=('libseccomp' 'nvidia-container-runtime-hook')
-provides=('nvidia-container-runtime=2.0.0+1.docker18.09.3')
+provides=('nvidia-container-runtime=2.0.0+3.docker18.09.6')
 conflicts=('nvidia-container-runtime')
 
-source=("https://nvidia.github.io/nvidia-container-runtime/centos7/$CARCH/${_pkgname}-2.0.0-1.docker18.09.3.$CARCH.rpm")
-sha256sums=('baa919c98282f9a722ef51f987d5d672941f8e68337e582cebfcb0606812eb68')
+source=("https://nvidia.github.io/nvidia-container-runtime/centos7/$CARCH/${_pkgname}-2.0.0-3.docker18.09.6.$CARCH.rpm")
+sha256sums=('1d23d648709a12f3245f138129e24837fb978c5ef75f51bce17c3c5a9d40d1ab')
 
 package() {
   cd "$srcdir"


### PR DESCRIPTION
should not be merged until we settle kiendang/aur-nvidia-container-runtime#2

@jshap70 I'm thinking of using the same version scheme as what we are using for `nvidia-container-runtime`, e.g `2.0.0+3.docker18.09.6`, following the same scheme the official Centos, Ubuntu packages use.